### PR TITLE
fix: 주문 테스트 응답상태 변경, 개별조회 api패스에 user추가

### DIFF
--- a/Backend/src/test/java/com/example/cafe/domain/order/controller/OrdersControllerTest.java
+++ b/Backend/src/test/java/com/example/cafe/domain/order/controller/OrdersControllerTest.java
@@ -91,7 +91,7 @@ public class OrdersControllerTest {
         result
                 .andExpect(handler().handlerType(OrderController.class))
                 .andExpect(handler().methodName("orderCreateResponse"))
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
 
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.email").value("test@example.com"))
@@ -131,7 +131,7 @@ public class OrdersControllerTest {
 
         // when
         ResultActions result = mvc.perform(
-                get("/api/v1/orders")
+                get("/api/v1/orders/user")
                         .param("email", "one@example.com")
                         .accept(MediaType.APPLICATION_JSON)
         ).andDo(print());
@@ -139,11 +139,10 @@ public class OrdersControllerTest {
         // then
         result
                 .andExpect(handler().handlerType(OrderController.class))
-                .andExpect(handler().methodName("getOrderByEmail")) // 실제 메서드명으로 변경 필요
+                .andExpect(handler().methodName("FindAllOrderByEmailResponse")) // 실제 메서드명으로 변경 필요
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value("one@example.com"))
-                .andExpect(jsonPath("$.id").exists())
-                .andExpect(jsonPath("$.items").isArray());
+                .andExpect(jsonPath("$.orders").isArray());
     }
 
     @Test


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- close #69 

## PR / 과제 설명 

- 주문 생성에 status 200으로 변경
- 단일 주문 조회 패스에 user 추가