### PR TITLE
OrderCreate 로직 최적화 및 DTO 통합 / Orders totalPrice 컬럼 추가

### DIFF
--- a/Backend/src/main/java/com/example/cafe/domain/item/repository/ItemRepository.java
+++ b/Backend/src/main/java/com/example/cafe/domain/item/repository/ItemRepository.java
@@ -2,7 +2,11 @@ package com.example.cafe.domain.item.repository;
 
 import com.example.cafe.domain.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
@@ -13,4 +17,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     // - findAll() : 전체 조회
     // - deleteById(id) : 삭제
 
+    //issue #76에 의해 추가 된 쿼리입니다.
+    @Query("select i from Item i where i.itemId in :itemIds")
+    List<Item> findSpecificItems(@Param("itemIds") List<Long> itemIds);
 }

--- a/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderByEmailResponse.java
+++ b/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderByEmailResponse.java
@@ -33,7 +33,7 @@ public class FindAllOrderByEmailResponse {
             this.orderId = order.getId();
             this.address = order.getAddress();
             this.orderDate = order.getOrderDate();
-            this.totalPrice = order.totalPrice();
+            this.totalPrice = order.getTotalPrice();
             this.deliveryStatus = order.calculateCurrentDeliveryStatus();
             this.items = order.
                     getOrderItems().

--- a/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderDto.java
+++ b/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderDto.java
@@ -23,7 +23,7 @@ public class FindAllOrderDto {
         this.email = order.getCustomerEmail();
         this.address = order.getAddress();
         this.orderDate = order.getOrderDate();
-        this.totalPrice = order.totalPrice();
+        this.totalPrice = order.getTotalPrice();
         this.deliveryStatus = order.calculateCurrentDeliveryStatus();
         this.items = order.
                 getOrderItems().

--- a/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderResponse.java
+++ b/Backend/src/main/java/com/example/cafe/domain/order/Dto/FindAllOrderResponse.java
@@ -3,6 +3,7 @@ package com.example.cafe.domain.order.Dto;
 import com.example.cafe.domain.order.Entity.Orders;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/Backend/src/main/java/com/example/cafe/domain/order/Dto/OrderCreateResponse.java
+++ b/Backend/src/main/java/com/example/cafe/domain/order/Dto/OrderCreateResponse.java
@@ -21,8 +21,8 @@ public class OrderCreateResponse {
         this.id = order.getId();
         this.email = order.getCustomerEmail();
         this.orderDate = order.getOrderDate();
-        this.totalPrice = order.totalPrice();
         this.deliveryStatus = order.calculateCurrentDeliveryStatus();
+        this.totalPrice = order.getTotalPrice();
         this.items = order.
                 getOrderItems().
                 stream().

--- a/Backend/src/main/java/com/example/cafe/domain/order/Entity/Orders.java
+++ b/Backend/src/main/java/com/example/cafe/domain/order/Entity/Orders.java
@@ -24,6 +24,8 @@ public class Orders {
 
     private String address;
 
+    private int totalPrice;
+
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<OrderItem> orderItems = new ArrayList<>();
 
@@ -42,12 +44,11 @@ public class Orders {
             orders.getOrderItems().add(orderItem);
             orderItem.setOrder(orders); //DB에는 적용되는데 영속성 컨텍스트에도 업로드를 해야합니다. jpa가 영속성 컨텍스트부터 봅니다.
         }
-
         return orders;
     }
 
-    public int totalPrice(){
-        return this
+    public void setTotalPrice(){
+        this.totalPrice = this
                 .getOrderItems()
                 .stream()
                 .mapToInt(m ->


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 관련 이슈

- close #76 

## PR / 과제 설명

OrderCreate 로직 
기존 방식: OrderItems의 item 추가를 위해
request시 받아오는 여러개의 item들을 리스트로 묶어 전체 item findAll후
loop하여 request에 해당하는 아이템 객체들만 뽑아서 추가했는데
이러면 데이터가 커질 경우 loop횟수가 많아질것 같아서 안좋아 보입니다.

수정 : 특정 item id만 리스트로 따와서 in절로 필요한 item객체만 찾은 후 담았습니다.

+ 기능 수정
totalPrice를 조회할 때도 계산하게 돼서 아이템이 수정되면 기존 정보가 날아가는 일이 생겨
totalPrice컬럼(필드)를 따로 만들고 주문을 생성할 때만 계산하도록 로직을 수정하였습니다.